### PR TITLE
fix: Preferred method returns highest PREF

### DIFF
--- a/card.go
+++ b/card.go
@@ -126,7 +126,7 @@ func (c Card) Preferred(k string) *Field {
 	}
 
 	field := fields[0]
-	max := 0
+	min := 100
 	for _, f := range fields {
 		n := 0
 		if pref := f.Params.Get(ParamPreferred); pref != "" {
@@ -136,8 +136,8 @@ func (c Card) Preferred(k string) *Field {
 			n = 1
 		}
 
-		if n > max {
-			max = n
+		if n < min {
+			min = n
 			field = f
 		}
 	}


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc6350#section-5.3:
`Its value MUST be an integer between 1 and 100 that
   quantifies the level of preference.  Lower values correspond to a
   higher level of preference, with 1 being most preferred.`